### PR TITLE
Introduce user context for phone components

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders landing page', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/join game/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Username from './signin/username';
 import PhoneGameView from './phone/game';
 import TVView from './tv/selectGame';
 import LandingPage from './landing';
+import { UserContext } from './UserContext';
 
 const appHeight = () => {
   const doc = document.documentElement
@@ -153,10 +154,14 @@ const App = () => {
   if (!username || !userId) {
     return <Username error={error} loading={loading} setName={(user) => setUser(user || "", gameId)} />;
   }
-  return <PhoneGameView userId={userId} username={username} gameId={gameId} gamePin={gamePin} gameInstanceId={gameInstanceId} logout={() => {
-    setUsername(undefined)
-    setGamePin(undefined)
-  }} />;
+  return (
+    <UserContext.Provider value={{ username: username as string | undefined, userId: userId as string | undefined, setUsername: setUsername as (name?: string) => void, setUserId: setUserId as (id?: string) => void }}>
+      <PhoneGameView gameId={gameId} gamePin={gamePin} gameInstanceId={gameInstanceId} logout={() => {
+        setUsername(undefined);
+        setGamePin(undefined);
+      }} />
+    </UserContext.Provider>
+  );
 }
 
 export default App;

--- a/src/UserContext.tsx
+++ b/src/UserContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+interface UserContextValue {
+  username?: string;
+  userId?: string;
+  setUsername?: (name?: string) => void;
+  setUserId?: (id?: string) => void;
+}
+
+export const UserContext = createContext<UserContextValue>({});
+
+export const useUser = () => useContext(UserContext);
+

--- a/src/components/TopRightPoints.tsx
+++ b/src/components/TopRightPoints.tsx
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
+import { useContext } from 'react';
+import { UserContext } from '../UserContext';
 
 interface TopRightProps {
-    username: String;
     points: number;
-    color: String;
+    color: string;
 }
 
-const TopRightPoints = ({ username, points, color }: TopRightProps) => {
+const TopRightPoints = ({ points, color }: TopRightProps) => {
+    const { username } = useContext(UserContext);
     return (
         <Wrapper hex={color}>
             <Username>{username}</Username>

--- a/src/phone/alts.tsx
+++ b/src/phone/alts.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import axios from "axios"
-import { useEffect, useRef, useState } from "react"
+import { useContext, useEffect, useRef, useState } from "react"
 import styled, { keyframes } from "styled-components"
 import { Question } from "../tv/game"
 import { GameWrapper, Header, Points, Username, MobileSpinner } from "./game"
@@ -10,6 +10,7 @@ import { MobileNav } from "../landing"
 import TopLeftLogo from "../components/TopLeftLogo"
 import TopRightPoints from "../components/TopRightPoints"
 import { selectableColors } from "./waiting"
+import { UserContext } from "../UserContext"
 import one from '../images/upgrades/1.png';
 import two from '../images/upgrades/2.png';
 import three from '../images/upgrades/3.png';
@@ -20,8 +21,6 @@ import seven from '../images/upgrades/7.png';
 import eight from '../images/upgrades/8.png';
 
 interface AltsProps {
-  userId: String
-  username: String
   points: number
   setPoints: (points: number) => void
   answered: () => void
@@ -35,7 +34,8 @@ interface AltsProps {
   color: number;
 }
 
-const Alts = ({ userId, username, points, setPoints, answered, gameId, gameInstanceId, question, fif, buyfif, stop, buyStop, color }: AltsProps) => {
+const Alts = ({ points, setPoints, answered, gameId, gameInstanceId, question, fif, buyfif, stop, buyStop, color }: AltsProps) => {
+  const { username, userId } = useContext(UserContext);
   const [roundPoints, setRoundPoints] = useState(0);
   const [score, setScore] = useState(1000);
 
@@ -170,7 +170,7 @@ const Alts = ({ userId, username, points, setPoints, answered, gameId, gameInsta
     <GameWrapper>
         <MobileNav>
           <TopLeftLogo />
-          <TopRightPoints username={username} points={points} color={selectableColors[color]}/>
+          <TopRightPoints points={points} color={selectableColors[color]}/>
         </MobileNav>
         <Text>Waiting for your score...</Text>
         <MobileSpinner/>
@@ -183,7 +183,7 @@ const Alts = ({ userId, username, points, setPoints, answered, gameId, gameInsta
     <GameWrapper style={{ background: answeredCorrectly ? 'linear-gradient(90deg, rgba(28,0,65,1) 0%, rgba(0,164,67,1) 0%, rgba(34,214,135,1) 100%)' : 'linear-gradient(90deg, rgba(28,0,65,1) 0%, rgba(255,39,39,1) 0%, rgba(247,89,89,1) 100%)' }}>
         <MobileNav>
           <TopLeftLogo />
-          <TopRightPoints username={username} points={points} color={selectableColors[color]}/>
+          <TopRightPoints points={points} color={selectableColors[color]}/>
         </MobileNav>
         <Text>{answeredCorrectly ? 'Correct' : 'Nope!'}</Text>
         <Text>You got {answeredCorrectly ? roundPoints : 0} points</Text>
@@ -196,7 +196,7 @@ const Alts = ({ userId, username, points, setPoints, answered, gameId, gameInsta
     <GameWrapper>
       <MobileNav>
         <TopLeftLogo />
-        <TopRightPoints username={username} points={points} color={selectableColors[color]}/>
+        <TopRightPoints points={points} color={selectableColors[color]}/>
       </MobileNav>
       
       <PowerUpContainer>

--- a/src/phone/game.tsx
+++ b/src/phone/game.tsx
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from "axios";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import styled, { keyframes } from "styled-components";
 import { Question } from "../tv/game";
 import Alts from "./alts";
@@ -10,19 +10,19 @@ import Waiting, { selectableColors } from "./waiting";
 import { MobileNav } from "../landing";
 import TopLeftLogo from "../components/TopLeftLogo";
 import TopRightPoints from "../components/TopRightPoints";
+import { UserContext } from "../UserContext";
 //import Waiting from "./waiting";
 import { useWakeLock } from 'react-screen-wake-lock';
 
 interface Game {
-    username: String,
     gameId: String,
     gamePin: String,
-    userId: String,
     gameInstanceId: String,
     logout: () => void
 }
 
-const PhoneGameView = ({ username, userId, gameId, gamePin, gameInstanceId, logout }: Game) => {
+const PhoneGameView = ({ gameId, gamePin, gameInstanceId, logout }: Game) => {
+  const { username, userId } = useContext(UserContext);
 
   // Maybe get user from session storage? and some way to reset it
   const [points, setPoints] = useState(0);
@@ -80,11 +80,10 @@ const PhoneGameView = ({ username, userId, gameId, gamePin, gameInstanceId, logo
 
   useEffect(() => {
     getQuestionsForGameId(gameId);
-    //getUser(username);
 
     // request wake lock
     request();
-  }, [gameId, username]);
+  }, [gameId]);
 
   const setAnswer = () => {
     setAnswered(true);
@@ -110,7 +109,7 @@ const PhoneGameView = ({ username, userId, gameId, gamePin, gameInstanceId, logo
 
     // Waiting for game to start
   if (!gameStarted) {
-    return <Waiting points={points} userId={userId} username={username} gameStarted={() => setGameStarted(true)} gamepin={gamePin} colorForUser={colorForUser} setColorForUser={setColorForUser} />
+    return <Waiting points={points} gameStarted={() => setGameStarted(true)} gamepin={gamePin} colorForUser={colorForUser} setColorForUser={setColorForUser} />
   }
 
   // view score when timer ends
@@ -122,18 +121,18 @@ const PhoneGameView = ({ username, userId, gameId, gamePin, gameInstanceId, logo
 
   // Show the questions alternatives and if the answer is correct
   if (!answered && !gameEnded) {
-    return <Alts question={questions[currentQ]} points={points} username={username} userId={userId} setPoints={(p) => setPoints(p)} answered={setAnswer} gameId={gameId} gameInstanceId={gameInstanceId} fif={fiftyfifty} buyfif={() => setFiftyfifty(false)} stop={stop} buyStop={() => setStoptime(false)} color={colorForUser}/>
+    return <Alts question={questions[currentQ]} points={points} setPoints={(p) => setPoints(p)} answered={setAnswer} gameId={gameId} gameInstanceId={gameInstanceId} fif={fiftyfifty} buyfif={() => setFiftyfifty(false)} stop={stop} buyStop={() => setStoptime(false)} color={colorForUser}/>
   }
 
   if (answered && !gameEnded) {
-    return <Result nextQuestionStarted={() => setAnswered(false)} currentQ={currentQ} points={points} setPoints={(p) => setPoints(p)} username={username} gamepin={gamePin} gameFinished={() => {setGameEnded(true); release()}} fif={fiftyfifty} buyfif={() => setFiftyfifty(true)} stop={stop} buyStop={() => setStoptime(true)} color={colorForUser}/>
+    return <Result nextQuestionStarted={() => setAnswered(false)} currentQ={currentQ} points={points} setPoints={(p) => setPoints(p)} gamepin={gamePin} gameFinished={() => {setGameEnded(true); release()}} fif={fiftyfifty} buyfif={() => setFiftyfifty(true)} stop={stop} buyStop={() => setStoptime(true)} color={colorForUser}/>
   }
 
   return(
     <GameWrapper onClick={() => setGameEnded(false)}>
       <MobileNav>
         <TopLeftLogo />
-        <TopRightPoints username={username} points={points} color={selectableColors[colorForUser]}/>
+        <TopRightPoints points={points} color={selectableColors[colorForUser]}/>
       </MobileNav>
       <Logo src={whiteLogo}/>
     </GameWrapper>

--- a/src/phone/result.tsx
+++ b/src/phone/result.tsx
@@ -1,12 +1,13 @@
 import axios, { AxiosRequestConfig } from "axios";
 import moment from "moment";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 import { GameWrapper, Header, MobileSpinner, Points, Username } from "./game";
 import { ItemImage, ItemImageMobile, MobileNav } from "../landing";
 import TopLeftLogo from "../components/TopLeftLogo";
 import TopRightPoints from "../components/TopRightPoints";
 import { selectableColors } from "./waiting";
+import { UserContext } from "../UserContext";
 import one from '../images/upgrades/1.png';
 import two from '../images/upgrades/2.png';
 import three from '../images/upgrades/3.png';
@@ -17,7 +18,6 @@ import seven from '../images/upgrades/7.png';
 import eight from '../images/upgrades/8.png';
 
 interface ResultProps {
-  username: String
   currentQ: number
   points: number
   nextQuestionStarted: () => void
@@ -31,7 +31,8 @@ interface ResultProps {
   color: number;
 }
 
-const Result = ({ currentQ, username, points, nextQuestionStarted, gamepin, gameFinished, fif, buyfif, setPoints, buyStop, stop, color }: ResultProps) => {
+const Result = ({ currentQ, points, nextQuestionStarted, gamepin, gameFinished, fif, buyfif, setPoints, buyStop, stop, color }: ResultProps) => {
+  const { username } = useContext(UserContext);
   
   const [getReady, setGetReady] = useState(false);
 
@@ -144,7 +145,7 @@ const Result = ({ currentQ, username, points, nextQuestionStarted, gamepin, game
       <GameWrapper>
           <MobileNav>
             <TopLeftLogo />
-            <TopRightPoints username={username} points={points} color={selectableColors[color]}/>
+            <TopRightPoints points={points} color={selectableColors[color]}/>
           </MobileNav>
           <Text>Get ready!</Text>
           <MobileSpinner/>
@@ -156,7 +157,7 @@ const Result = ({ currentQ, username, points, nextQuestionStarted, gamepin, game
     <GameWrapper>
       <MobileNav>
         <TopLeftLogo />
-        <TopRightPoints username={username} points={points} color={selectableColors[color]}/>
+        <TopRightPoints points={points} color={selectableColors[color]}/>
       </MobileNav>
         <UpgradeContainer>
           <PowerUp onClick={purchaseFifityFifty}>

--- a/src/phone/waiting.tsx
+++ b/src/phone/waiting.tsx
@@ -1,13 +1,12 @@
 import axios, { AxiosRequestConfig } from "axios";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 import TopLeftLogo from "../components/TopLeftLogo";
 import TopRightPoints from "../components/TopRightPoints";
 import { HeaderMobile, MobileHeader, MobileNav } from "../landing";
+import { UserContext } from "../UserContext";
 
 interface WaitingProps {
-  username: String;
-  userId: String;
   points: number
   gameStarted: () => void
   gamepin: String
@@ -22,7 +21,8 @@ export const selectableColors = [
   '#000000',
 ]
 
-const Waiting = ({ username, userId, points, gameStarted, gamepin, colorForUser, setColorForUser }: WaitingProps) => {
+const Waiting = ({ points, gameStarted, gamepin, colorForUser, setColorForUser }: WaitingProps) => {
+  const { username, userId } = useContext(UserContext);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -57,7 +57,7 @@ const Waiting = ({ username, userId, points, gameStarted, gamepin, colorForUser,
     <MobileGameWrapper>
       <MobileNav>
       <TopLeftLogo />
-      <TopRightPoints username={username} points={points} color={selectableColors[colorForUser]}/>
+      <TopRightPoints points={points} color={selectableColors[colorForUser]}/>
       </MobileNav>
       <BlueWrapper>
         <MobileHeader>Waiting for game to begin...</MobileHeader>


### PR DESCRIPTION
## Summary
- add reusable `UserContext` for username and userId
- refactor phone components to consume user info from context instead of props
- adjust test to reflect landing page

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6893359fa9f0832f9bc15ef7c1fd4547