### PR TITLE
feat: add react router

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 
 test('renders landing page', () => {
-  render(<App />);
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
   const linkElement = screen.getByText(/join game/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,13 @@ import PhoneGameView from './phone/game';
 import TVView from './tv/selectGame';
 import { UserContext } from './UserContext';
 
+const appHeight = () => {
+  const doc = document.documentElement
+  doc.style.setProperty(' — app-height', `${window.innerHeight}px`)
+ }
+ window.addEventListener('resize', appHeight)
+ appHeight()
+
 const App = () => {
   const navigate = useNavigate();
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import './soopafresh.ttf';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -18,7 +19,9 @@ appHeight()
 
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/src/signin/username.tsx
+++ b/src/signin/username.tsx
@@ -7,11 +7,11 @@ import TopLeftLogo from "../components/TopLeftLogo";
 interface UsernameProps {
     error: boolean,
     loading: boolean,
-    setName: (name: String | undefined) => void
+    setName: (name: string | undefined) => void
 }
 
 const Username = ({ setName, loading, error }: UsernameProps) => {
-    const [username, setUsername] = useState<String | undefined>("");
+    const [username, setUsername] = useState<string | undefined>("");
     const [validationError, setValidationError] = useState<string | undefined>("");
 
     const validateName = (input: any) => {
@@ -45,7 +45,7 @@ const Username = ({ setName, loading, error }: UsernameProps) => {
                 <>
                     {error && <ErrorText>Already taken. Try another pls?</ErrorText>}
                     {validationError && <ErrorText>{validationError}</ErrorText>}
-                    <TextInputField placeholder="Username" onChange={(e: { target: { value: String; }; }) => setUsername(e.target.value)} onKeyPress={(e: any)  => {
+                    <TextInputField placeholder="Username" onChange={(e: { target: { value: String; }; }) => setUsername(e.target.value.toString())} onKeyPress={(e: any)  => {
                         if ((e.key === 'Enter') && ((e.target as HTMLTextAreaElement).value !== undefined)) {
                             setValidationError("");
                             if (validateName(username)) {


### PR DESCRIPTION
## Summary
- integrate React Router for landing, TV, and phone game flows
- wrap root rendering in BrowserRouter
- adjust unit test to render within a router

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68933ab15e6c832f9f72f28a4baa3d50