### PR TITLE
docs: add websocket setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
-React front-end in /frontend
-PHP rest api in /rest-api
-Socket.io and Node server in /websocket api
+# Gunwale
+
+## Components
+- React front-end in `/frontend`.
+- PHP REST API in `/rest-api` (used for non-time-critical operations).
+- Socket.io and Node WebSocket server in `/websocket-api`.
+
+## Running the WebSocket server
+1. `cd websocket-api`
+2. `npm install`
+3. Copy `.env.example` to `.env` and adjust `PORT`, `CLIENT_URL`, and `API_URL`.
+4. `npm start`
+
+## Running the front-end
+1. Ensure the WebSocket server is running.
+2. In `/frontend`, set `REACT_APP_WS_URL` to the server URL, e.g. in a `.env` file:
+   ```
+   REACT_APP_WS_URL=http://localhost:3000
+   ```
+3. `npm start`
+
+The REST API continues to handle operations that are not time-critical.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,15 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## WebSocket client
+
+1. Start the WebSocket server from `../websocket-api` using `npm start`.
+2. Create a `.env` file with the server URL:
+   ```
+   REACT_APP_WS_URL=http://localhost:3000
+   ```
+3. Run `npm start` to launch the React app.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/websocket-api/README.md
+++ b/websocket-api/README.md
@@ -27,6 +27,10 @@ Serveren starter på angitt `PORT` og eksponerer Socket.IO-endepunktet.
 
 ### Events
 
-- `join_game` – klienten melder seg inn i et spill (room).
-- `player_update` – videresendes til alle i rommet.
-- `game_status` – sendes periodisk fra serveren.
+| Event | Payload | Respons |
+|-------|---------|---------|
+| `join_game` | `gameId` (string) | Ingen direkte respons, socketen joiner rommet for spillet. |
+| `player_update` | Objekt med minst `gameId` og øvrige spillerdata | Broadcastes som `player_update` til alle klienter i samme rom. |
+| `game_status` | Objekt, valgfritt `gameId` | Broadcastes som `game_status` til rommet eller alle klienter. Serveren sender også periodisk status fra REST-APIet. |
+
+REST-APIet brukes fortsatt for operasjoner som ikke er tidskritiske.


### PR DESCRIPTION
## Summary
- document how to start the WebSocket server and configure the client
- detail WebSocket event payloads and responses, noting REST API for non-time-critical work

## Testing
- `npm test` (websocket-api)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68945aca8d5c832fad00fd3acda31e80