### PR TITLE
Add Dockerfile and environment docs for websocket API

### DIFF
--- a/websocket-api/Dockerfile
+++ b/websocket-api/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
+ENV PORT=3000
+EXPOSE $PORT
+CMD ["npm", "start"]

--- a/websocket-api/README.md
+++ b/websocket-api/README.md
@@ -9,13 +9,17 @@ npm install
 cp .env.example .env
 ```
 
-Rediger `.env` etter behov. Typiske variabler:
+Rediger `.env` etter behov.
 
-```
-PORT=3000
-CLIENT_URL=http://localhost:5173
-API_URL=http://localhost:8000
-```
+## Miljøvariabler
+
+Serveren bruker følgende variabler:
+
+| Variabel | Beskrivelse | Standard |
+|---------|-------------|----------|
+| `PORT` | Porten serveren lytter på. | `3000` |
+| `CLIENT_URL` | URL til klienten som tillates via CORS. | `*` |
+| `API_URL` | Base-URL til REST-APIet for periodiske statusoppdateringer. | – |
 
 ## Kjøring
 


### PR DESCRIPTION
## Summary
- build websocket-api image with Node 18 and npm ci
- document required PORT, CLIENT_URL and API_URL environment variables

## Testing
- `cd websocket-api && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68948fe2c720832fad7e9102cc5ffc93