### PR TITLE
feat(frontend): add Dockerfile for static build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Build the application
+COPY . .
+ARG REACT_APP_WS_URL
+ENV REACT_APP_WS_URL=$REACT_APP_WS_URL
+RUN npm run build
+
+# Production image
+FROM nginx:alpine
+ARG REACT_APP_WS_URL
+ENV REACT_APP_WS_URL=$REACT_APP_WS_URL
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- build frontend with node 18 and serve via nginx
- pass through REACT_APP_WS_URL build arg and expose port 80

## Testing
- `cd frontend && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68949007f96c832fa27c9b4295330cd8