### PR TITLE
Add docker-compose configuration for frontend and websocket services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.9"
+
+services:
+  websocket:
+    build: ./websocket-api
+    ports:
+      - "3000:3000"
+    env_file:
+      - ./websocket-api/.env
+    networks:
+      - app-network
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "5173:80"
+    environment:
+      - REACT_APP_WS_URL=http://websocket:3000
+    depends_on:
+      - websocket
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- add root `docker-compose.yml` defining `websocket` and `frontend` services on a shared network
- pass `REACT_APP_WS_URL` to the frontend so it can reach the websocket service

## Testing
- `docker compose up --build` *(fails: `docker: 'compose' is not a docker command`)*
- `docker-compose up --build` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_689495593a30832fb5160842dd1a4a5d