### PR TITLE
Handle CORS preflight requests

### DIFF
--- a/rest-api/api.php
+++ b/rest-api/api.php
@@ -1,5 +1,13 @@
 <?php
  header("Access-Control-Allow-Origin: *");
+ header("Access-Control-Allow-Methods: GET, POST, PUT, OPTIONS");
+ header("Access-Control-Allow-Headers: Content-Type");
+
+ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+     http_response_code(204);
+     exit;
+ }
+
 // get the HTTP method, path and body of the request
 $method = $_SERVER['REQUEST_METHOD'];
 $request = explode('/', trim($_SERVER['PATH_INFO'],'/'));


### PR DESCRIPTION
## Summary
- add Access-Control-Allow-Methods and Access-Control-Allow-Headers to REST API
- return 204 for OPTIONS requests to support CORS preflight

## Testing
- `php -l rest-api/api.php`
- `php -S 127.0.0.1:8000 -t rest-api & curl -i -X OPTIONS http://127.0.0.1:8000/api.php`


------
https://chatgpt.com/codex/tasks/task_e_6895ade57f4c832f8b18358409313ecc