### PR TITLE
feat: configure socket.io endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,9 +50,10 @@ services:
       - app-network
 
   frontend:
-    build: ./frontend
-    environment:
-      - REACT_APP_WS_URL=wss://ovh.tavl.no/ws
+    build:
+      context: ./frontend
+      args:
+        REACT_APP_WS_URL: wss://ovh.tavl.no
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.frontend.rule=Host(`ovh.tavl.no`)"

--- a/frontend/src/api/socket.ts
+++ b/frontend/src/api/socket.ts
@@ -1,7 +1,6 @@
 import { io } from 'socket.io-client';
 
-const socketUrl = process.env.REACT_APP_WS_URL || '';
-
-export const socket = io(socketUrl);
+const socketUrl = process.env.REACT_APP_WS_URL || 'wss://ovh.tavl.no';
+export const socket = io(socketUrl, { path: '/ws/socket.io' });
 
 export default socket;


### PR DESCRIPTION
## Summary
- default socket.io client to `wss://ovh.tavl.no` with explicit `/ws/socket.io` path
- pass `REACT_APP_WS_URL` build arg in frontend service

## Testing
- `CI=true npm test`
- `docker-compose build` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))*
- `curl -i -N -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: SGVsbG8sIHdvcmxkIQ==" -H "Origin: https://ovh.tavl.no" https://ovh.tavl.no/ws/socket.io/?EIO=4&transport=websocket` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895adf32978832fbcb3b663fefd6647