### PR TITLE
Serve SPA paths via Nginx

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,5 +16,6 @@ FROM nginx:alpine
 ARG REACT_APP_WS_URL
 ENV REACT_APP_WS_URL=$REACT_APP_WS_URL
 COPY --from=build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    location / {
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx.conf to redirect non-file paths to index.html so SPA works on subpaths
- copy new nginx.conf in frontend Dockerfile

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895b4e6f9dc832fae76f180310d84bc