### PR TITLE
Add Keycloak and PostgreSQL services to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,39 @@ services:
     networks:
       - app-network
 
+  keycloak-db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: ${KC_DB_USERNAME}
+      POSTGRES_PASSWORD: ${KC_DB_PASSWORD}
+    volumes:
+      - keycloak-db-data:/var/lib/postgresql/data
+    networks:
+      - app-network
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    command:
+      - start --optimized
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://keycloak-db:5432/keycloak
+      KC_DB_USERNAME: ${KC_DB_USERNAME}
+      KC_DB_PASSWORD: ${KC_DB_PASSWORD}
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_HOSTNAME: auth.tavl.no
+    expose:
+      - "8080"
+    depends_on:
+      - keycloak-db
+    networks:
+      - app-network
+
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  keycloak-db-data:


### PR DESCRIPTION
## Summary
- add Keycloak PostgreSQL database with persistent volume
- configure Keycloak service for production with required environment variables

## Testing
- `python3 - <<'PY'
import yaml
yaml.safe_load(open('docker-compose.yml'))
print('YAML OK')
PY`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c3c2b9e8832fbaed3c2e7a3056af