### PR TITLE
Add Traefik labels for Keycloak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,12 @@ services:
       KC_HOSTNAME: auth.tavl.no
     expose:
       - "8080"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.keycloak.rule=Host(`auth.tavl.no`)"
+      - "traefik.http.routers.keycloak.entrypoints=websecure"
+      - "traefik.http.routers.keycloak.tls.certresolver=myresolver"
+      - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
     depends_on:
       - keycloak-db
     networks:


### PR DESCRIPTION
## Summary
- add Traefik router and service labels to the Keycloak container so traffic to `auth.tavl.no` is handled by Traefik

## Testing
- `docker compose up -d` *(fails: command not found: docker; installed docker and ran `docker-compose up -d` but it failed to connect to Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_6895ceb536f0832fbfd902ccc7a6e0d5