### PR TITLE
feat: add AdSense component

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,6 +9,7 @@
     <link rel="manifest" href="/site.webmanifest">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta name="google-adsense-account" content="ca-pub-2734447254840350">
     <meta
       name="description"
       content="Tavl web quizes"

--- a/frontend/src/components/Ads.tsx
+++ b/frontend/src/components/Ads.tsx
@@ -7,7 +7,7 @@ const Ads = () => {
             const script = document.createElement('script');
             script.id = scriptId;
             script.async = true;
-            script.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-xxxxxxxxxxxxxxxx';
+            script.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2734447254840350';
             script.crossOrigin = 'anonymous';
             script.onload = () => {
                 (window as any).adsbygoogle = (window as any).adsbygoogle || [];
@@ -24,7 +24,7 @@ const Ads = () => {
         <ins
             className="adsbygoogle"
             style={{ display: 'block' }}
-            data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+            data-ad-client="ca-pub-2734447254840350"
             data-ad-slot="1234567890"
             data-ad-format="auto"
             data-full-width-responsive="true"


### PR DESCRIPTION
## Summary
- add Ads component that injects the AdSense script and renders an ad container

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689a30603230832f90c9878a051a6625