### PR TITLE
feat: refresh landing page with gradients

### DIFF
--- a/frontend/src/components/PrimaryButton.tsx
+++ b/frontend/src/components/PrimaryButton.tsx
@@ -50,12 +50,15 @@ const Button = styled.div.attrs((props: {loading: string}) => props)`
     line-height: 1.5;
     color: white;
     background-clip: padding-box;
-    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, background-position .3s ease, transform .3s ease;
     max-width: 500px;
     margin: auto;
-      
-    background: #9C8AFA;
-       
+    background: linear-gradient(135deg, #6A71FA 0%, #9C8AFA 100%);
+    background-size: 200% 200%;
     cursor: ${props => props.loading === "true"  ? 'default' : 'pointer'};
     border-radius: 15px;
+    &:hover {
+        background-position: 100% 0;
+        transform: ${props => props.loading === "true" ? 'none' : 'translateY(-2px)'};
+    }
 `;

--- a/frontend/src/components/SecondaryButton.tsx
+++ b/frontend/src/components/SecondaryButton.tsx
@@ -23,12 +23,15 @@ const Button = styled.div`
     line-height: 1.5;
     color: white;
     background-clip: padding-box;
-    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, background-position .3s ease, transform .3s ease;
     max-width: 500px;
     margin: auto;
-      
-    background: #6A71FA;
-       
+    background: linear-gradient(135deg, #6A71FA 0%, #9C8AFA 100%);
+    background-size: 200% 200%;
     cursor: pointer;
     border-radius: 15px;
+    &:hover {
+        background-position: 100% 0;
+        transform: translateY(-2px);
+    }
 `;

--- a/frontend/src/landing.tsx
+++ b/frontend/src/landing.tsx
@@ -14,6 +14,30 @@ import seven from './images/upgrades/7.png';
 import eight from './images/upgrades/8.png';
 import WhiteButton from './components/WhiteButton';
 
+const gradient = keyframes`
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+`;
+
+const fadeUp = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+
 interface SiginProps {
     signIn: () => void
     playMode: () => void
@@ -248,7 +272,9 @@ export const MobileHeader = styled.div`
 `;
 
 const BlueWrapper = styled.div`
-  background-image: linear-gradient(180deg, #6A71FA 0%, #9C8AFA 100%);
+  background: linear-gradient(135deg, #6A71FA 0%, #9C8AFA 50%, #6A71FA 100%);
+  background-size: 200% 200%;
+  animation: ${gradient} 10s ease infinite;
   width: 100%;
 `;
 
@@ -327,6 +353,7 @@ const pulse = keyframes`
   }
 `;
 
+
 const UpgradeItemMobile = styled.div`
     display: flex;
     padding-left: 30px;
@@ -371,6 +398,7 @@ const ContentLeft = styled.div`
     transform: translate(-50%, -50%);
     min-width: 300px;
     max-width: 80vw;
+    animation: ${fadeUp} 1s ease forwards;
     @media (max-width: 1160px) {
       left: 50%;
     }
@@ -383,6 +411,7 @@ const ContentRight = styled.div`
     transform: translate(-50%, -50%);
     min-width: 300px;
     max-width: 80vw;
+    animation: ${fadeUp} 1s ease forwards;
     @media (max-width: 1160px) {
       display: none;
       left: 50%;
@@ -400,7 +429,9 @@ const LeftSide = styled.div`
 
 const RightSide = styled.div`
   width: 50%;
-  #background-image: linear-gradient(180deg, #6A71FA 0%, #9C8AFA 100%);
+  background: linear-gradient(135deg, #6A71FA 0%, #9C8AFA 50%, #6A71FA 100%);
+  background-size: 200% 200%;
+  animation: ${gradient} 10s ease infinite;
   @media (max-width: 1160px) {
     display: none;
     width: 100;


### PR DESCRIPTION
## Summary
- introduce animated gradient and fade-up keyframes for a more dynamic landing page
- enhance hero and mobile sections with animated gradients
- update primary and secondary buttons with gradient backgrounds and hover animations

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689a38fe7a88832f8913f5ed21730301